### PR TITLE
docs: Use gif in README instead of mov

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,5 @@ Using `console.count()` is a very handy way to check for unwanted renders in web
 
 ## How to use it
 Place `fCount(*label_name*)` inside any build function and check the logs. Every time the function is called, log prints the total no of times it has been executed.
-https://user-images.githubusercontent.com/13520364/181412051-98d29a3a-45ab-473c-8768-c4821a670b69.mov
 
-
+![output](https://user-images.githubusercontent.com/34758667/181426733-4fc6b4d2-99d6-44df-b5e1-24d7163eabf9.gif)


### PR DESCRIPTION
Trimmed the video to 30s